### PR TITLE
Increase width for boot menu (Fedora has longer menuentry names)

### DIFF
--- a/customize/fedora/theme.txt
+++ b/customize/fedora/theme.txt
@@ -17,7 +17,7 @@ terminal-border: "0"
 + boot_menu {
   left = 15%
   top = 40%
-  width = 27%
+  width = 60%
   height = 65%
   item_font = "Ubuntu Regular 20"
   item_color = "#cccccc"


### PR DESCRIPTION
Increase width to accommodate long menuentry like`Fedora Linux (5.1x.xx-xxx.fc35.x86_64) 35 (Workstation Edition)`

![image](https://user-images.githubusercontent.com/66936172/149625909-40a30abf-982d-4a4d-bc73-48277698d68e.png)
