### PR TITLE
Added instructions to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ sudo pacman -S grub-customizer
 ```
 Dnf
 
-**Grub Customizer DOES NOT WORK on recent Fedora releases without extensive modification. [Manually installing](#manual-installation) is much more secure and hassle free.**
+**Grub Customizer DOES NOT WORK on recent Fedora releases without extensive modification. [Manually installing](#manual-installation) a GRUB theme is much more secure and hassle free.**
 
 ```
 sudo dnf install grub-customizer

--- a/README.md
+++ b/README.md
@@ -318,13 +318,15 @@ inxi -M | grep -i 'UEFI\|BIOS'
 If you have a BIOS system, run:
 
 ```
-sudo grub-mkconfig -o /boot/grub/grub.cfg
+sudo grub-mkconfig -o /etc/grub.cfg
+or
+sudo grub2-mkconfig -o /etc/grub2.cfg
 ```
 
 If you have a UEFI system, run:
 
 ```
-sudo grub2-mkconfig /etc/grub2-efi.cfg
+sudo grub2-mkconfig -o /etc/grub2.cfg && sudo grub2-mkconfig -o /etc/grub2-efi.cfg && sudo grub2-mkconfig /etc/grub2-efi.cfg
 ```
 
 ## Install theme in Ventoy

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Theme must be unpacked (in folder)
 ```
 sudo cp -r <theme_name>/ /boot/grub/themes
 or
-sudo cp -r <theme_name>/ /boot/grub2/theme
+sudo cp -r <theme_name>/ /boot/grub2/themes
 ```
 
 #### Edit Grub config
@@ -285,6 +285,8 @@ At the end of file add theme path:
 
 ```
 GRUB_THEME="/boot/grub/themes/<theme_name>/theme.txt"
+or
+GRUB_THEME="/boot/grub2/themes/<theme_name>/theme.txt"
 ```
 
 ### Note:

--- a/README.md
+++ b/README.md
@@ -201,6 +201,13 @@ Eopkg
 ```
 sudo eopkg install grub-customizer
 ```
+Dnf/Fedora
+
+**Grub Customizer DOES NOT WORK on recent Fedora releases without extensive modification. [Manually installing](#manual-installation) is much more secure and hassle free.**
+
+```
+sudo dnf install grub-customizer
+```
 
 ### Install pre-made theme with Grub Customizer
 
@@ -283,16 +290,29 @@ Ctrl+O to save, Ctrl+X to exit
 
 You will need to tell Grub to update its configuration to include the new theme.
 
-Ubuntu and Debian-based systems:
+##### Ubuntu and Debian-based systems:
 
 ```
 sudo update-grub
 ```
 
-Other Linux distro:
+##### Fedora, Arch & Other Linux distros: 
+
+To find out whether you have a BIOS or UEFI system, run the following command in a terminal:
+```
+inxi -M | grep -i 'UEFI\|BIOS'
+```
+
+If you have a BIOS system, run:
 
 ```
 sudo grub-mkconfig -o /boot/grub/grub.cfg
+```
+
+If you have a UEFI system, run:
+
+```
+sudo grub2-mkconfig /etc/grub2-efi.cfg
 ```
 
 ## Install theme in Ventoy

--- a/README.md
+++ b/README.md
@@ -195,18 +195,18 @@ Pacman
 ```
 sudo pacman -S grub-customizer
 ```
-
-Eopkg
-
-```
-sudo eopkg install grub-customizer
-```
-Dnf/Fedora
+Dnf
 
 **Grub Customizer DOES NOT WORK on recent Fedora releases without extensive modification. [Manually installing](#manual-installation) is much more secure and hassle free.**
 
 ```
 sudo dnf install grub-customizer
+```
+
+Eopkg
+
+```
+sudo eopkg install grub-customizer
 ```
 
 ### Install pre-made theme with Grub Customizer

--- a/README.md
+++ b/README.md
@@ -197,9 +197,10 @@ sudo pacman -S grub-customizer
 ```
 Dnf
 
-**Grub Customizer DOES NOT WORK on recent Fedora releases without extensive modification. [Manually installing](#manual-installation) a GRUB theme is much more secure and hassle free.**
+**WARNING:Grub Customizer DOES NOT WORK on recent Fedora releases without extensive modification. [Manually installing](#manual-installation) a GRUB theme is much more secure and hassle free.**
 
 ```
+Use at own risk.
 sudo dnf install grub-customizer
 ```
 
@@ -328,6 +329,7 @@ If you have a UEFI system, run:
 ```
 sudo grub2-mkconfig -o /etc/grub2.cfg && sudo grub2-mkconfig -o /etc/grub2-efi.cfg && sudo grub2-mkconfig /etc/grub2-efi.cfg
 ```
+**WARNING:These commands have only been tested on Fedora UEFI. If you are able to install a GRUB theme using these commands successfully, please add your distro's name here.**
 
 ## Install theme in Ventoy
 

--- a/README.md
+++ b/README.md
@@ -247,6 +247,8 @@ git clone https://github.com/AdisonCavani/distro-grub-themes.git
 
 ```
 sudo mkdir /boot/grub/themes
+or
+sudo mkdir /boot/grub2/themes
 ```
 
 #### Edit or use pre-made theme
@@ -260,7 +262,9 @@ cd distro-grub-themes/customize
 Theme must be unpacked (in folder)
 
 ```
-sudo cp -r ubuntu/ /boot/grub/themes
+sudo cp -r <theme_name>/ /boot/grub/themes
+or
+sudo cp -r <theme_name>/ /boot/grub2/theme
 ```
 
 #### Edit Grub config
@@ -280,10 +284,16 @@ GRUB_GFXMODE=1920x1080
 At the end of file add theme path:
 
 ```
-GRUB_THEME="/boot/grub/themes/ubuntu/theme.txt"
+GRUB_THEME="/boot/grub/themes/<theme_name>/theme.txt"
 ```
 
-Replace "ubuntu" with selected theme<br>
+### Note:
+- **Replace "<theme_name>" with selected theme's name.**
+
+- **To check what name your distro has given the GRUB folder, run:**
+  ``` 
+  ls /boot | grep -i -w 'grub\|grub2'
+  ```
 Ctrl+O to save, Ctrl+X to exit
 
 #### Update Grub config


### PR DESCRIPTION
# Description

- Added instructions for Fedora and, by extension, RHEL based distros.
- Put in a warning to not use Grub-Customizer in Fedora 
- Added a note for the user to double-check the name for their GRUB folder and input the correct paths in the terminal
- Replaced "ubuntu" in the manual installation page with a generic name
- Changed order of points in the Grub-Customizer installation section
- Added the correct Grub update commands for UEFI and BIOS systems.

Fixes # (issue)

## Type of change

- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project (correct file and folder structure)
- [x] The background image for theme is called ``background.png``
- [x] ``theme.txt`` has correct *'desktop-image: "background.png"'* attribute
