### PR TITLE
fix: manual installation process updated

### DIFF
--- a/docs/Installation.mdx
+++ b/docs/Installation.mdx
@@ -108,15 +108,15 @@ sudo mkdir BOOT_GRUB_LOCATION/themes
 #### Edit or use a pre-made theme
 
 ```shell
-cd distro-grub-themes/customize
+cd distro-grub-themes/themes
 ```
 
 #### Copy theme
 
-The theme must be unpacked inside a folder before you can copy it.
+The theme must be unpacked inside a folder before you can install it.
 
 ```
-sudo cp -r <theme_name>/ BOOT_GRUB_LOCATION/themes
+sudo tar -C BOOT_GRUB_LOCATION/themes/<theme_name> -xf <theme_name>.tar
 ```
 
 #### Edit GRUB config


### PR DESCRIPTION
# Description

I installed a fresh copy of Debian 12 on my laptop, cloned the project, and realized that the manual installation process was outdated because the `/customize` folder was part of a legacy distribution of this package.

I took it upon myself to update the documentation for this process, and it should work seamlessly for new users who are trying to follow this part of the guide.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:
(I have not updated any part of this side, nor have I added a new theme.)
- [x] My code follows the style guidelines of this project (correct file and folder structure)
- [x] The background image for theme follows naming convention: `theme_name.png`
- [x] I updated [`themes.json`](https://github.com/AdisonCavani/distro-grub-themes/blob/master/themes.json) file (JSON database)
