### PR TITLE
Fix build errors for nix flake

### DIFF
--- a/build/module.nix
+++ b/build/module.nix
@@ -1,4 +1,4 @@
-{ pks, lib, config, ... }:
+{ pkgs, lib, config, ... }:
 with lib;
 let
   cfg = config.distro-grub-themes;

--- a/build/module.nix
+++ b/build/module.nix
@@ -22,7 +22,7 @@ in
     {
       boot.loader.grub = {
         theme = pkgs.callPackage ./default.nix { theme = cfg.theme; };
-        splashImage = ./../assets/splash_image.jpg;
+        splashImage = ./assets/splash_image.jpg;
       };
     };
 }

--- a/build/module.nix
+++ b/build/module.nix
@@ -22,7 +22,7 @@ in
     {
       boot.loader.grub = {
         theme = pkgs.callPackage ./default.nix { theme = cfg.theme; };
-        splashImage = ./assets/splash_image.jpg;
+        splashImage = ./../assets/splash_image.jpg;
       };
     };
 }


### PR DESCRIPTION
# Description

Fix errors building theme when using nix flake as described in ./docs/Installation.mdx#installation-via-nix-flakes:
1. Fix path to splash image
2. Fix typo in package name

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project (correct file and folder structure)
- [ ] The background image for theme follows naming convention: `theme_name.png`
- [ ] I updated [`themes.json`](https://github.com/AdisonCavani/distro-grub-themes/blob/master/themes.json) file (JSON database)
